### PR TITLE
[PPT-273] Fix postalIbanHolder in transfers mapper

### DIFF
--- a/payments/pom.xml
+++ b/payments/pom.xml
@@ -141,14 +141,6 @@
             </exclude>
           </excludes>
         </configuration>
-        <executions>
-          <execution>
-            <id>repackage</id>
-            <configuration>
-              <classifier>exec</classifier>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/payments/src/main/java/it/gov/pagopa/hubpa/payments/mapper/ConvertDebitorModelToDebitor.java
+++ b/payments/src/main/java/it/gov/pagopa/hubpa/payments/mapper/ConvertDebitorModelToDebitor.java
@@ -99,7 +99,7 @@ public class ConvertDebitorModelToDebitor implements Converter<DebitorModel, Deb
 	transfers.setReason(transfersModel.getReason());
 	transfers.setTaxonomy(transfersModel.getTaxonomy());
 	transfers.setPostalIban(transfersModel.getPostalIban());
-	transfers.setPostalIbanHolder(transfersModel.getPostalAuthCode());
+	transfers.setPostalIbanHolder(transfersModel.getPostalIbanHolder());
 	transfers.setPostalAuthCode(transfersModel.getPostalAuthCode());
 	return transfers;
     }

--- a/payments/src/test/java/it/gov/pagopa/hubpa/payments/controller/PaymentsControllerTest.java
+++ b/payments/src/test/java/it/gov/pagopa/hubpa/payments/controller/PaymentsControllerTest.java
@@ -244,6 +244,14 @@ class PaymentsControllerTest {
 		assertThat(paymentsModel.getDebitors().get(0).getPaymentPosition().get(0).getPaymentOptions().get(0)
 				.getTransfers().get(1).getPostalAuthCode())
 						.isEqualTo(uploadCsvModelMock.getTributeService().getPostalAuthCodeSecondary());
+		assertThat(paymentsModel.getDebitors().get(0).getPaymentPosition().get(0).getPaymentOptions().get(0)
+				.getTransfers().get(0).getPostalIbanHolder())
+						.isEqualTo(uploadCsvModelMock.getTributeService().getPostalIbanHolderPrimary());
+
+		assertThat(paymentsModel.getDebitors().get(0).getPaymentPosition().get(0).getPaymentOptions().get(0)
+				.getTransfers().get(1).getPostalIbanHolder())
+						.isEqualTo(uploadCsvModelMock.getTributeService().getPostalIbanHolderSecondary());
+
 	}
 
 	@Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Fixed postalIbanHolder in transfers mapper;
- updated tests.

#### Motivation and Context

The goal of this PR is to fix the value of postal data in the Transfer table of the _Payments microservice_, in particular the field _postaIbanHolder_ which is currently set with _postalAuthCode_.

#### How Has This Been Tested?

- unit test;
- scripts in resources.

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
